### PR TITLE
.lintstagedrc.js の記述ミスにより stylelint が lint-staged 経由で動いていなかった問題を修正

### DIFF
--- a/.lintstagedrc.js
+++ b/.lintstagedrc.js
@@ -1,4 +1,4 @@
 module.exports = {
   '*.js': (files) => `yarn run eslint ${files.join(' ')}`,
-  '*.?(s)css': (files) => `yarn run styleline ${files.join(' ')}`
+  '*.?(s)css': (files) => `yarn run stylelint ${files.join(' ')}`
 }


### PR DESCRIPTION
記述ミスがあったので修正