### PR TITLE
現状、基本的にすべてのプロジェクトで利用している destyle.css を boilerplate に含める

### DIFF
--- a/frontend/stylesheets/main.scss
+++ b/frontend/stylesheets/main.scss
@@ -1,0 +1,1 @@
+@import "destyle.css"

--- a/package.json
+++ b/package.json
@@ -33,6 +33,7 @@
     "autoprefixer": "^10.3.1",
     "browserslist": "^4.16.7",
     "csstools-postcss-sass-pre-release": "^5.0.0-dev.1",
+    "destyle.css": "^3.0.2",
     "esbuild": "^0.13.4",
     "eslint": "^7.32.0",
     "eslint-config-standard": "^16.0.3",

--- a/yarn.lock
+++ b/yarn.lock
@@ -953,6 +953,11 @@ dependency-graph@^0.9.0:
   resolved "https://registry.yarnpkg.com/dependency-graph/-/dependency-graph-0.9.0.tgz#11aed7e203bc8b00f48356d92db27b265c445318"
   integrity sha512-9YLIBURXj4DJMFALxXw9K3Y3rwb5Fk0X5/8ipCzaN84+gKxoHK43tVKRNakCQbiEx07E8Uwhuq21BpUagFhZ8w==
 
+destyle.css@^3.0.2:
+  version "3.0.2"
+  resolved "https://registry.yarnpkg.com/destyle.css/-/destyle.css-3.0.2.tgz#80c331db91f02337040b62dc534ab4f3dc075546"
+  integrity sha512-OUzuAlridP01YP0seHxx+FgwhdXF07Ls9NxnJpR8EI7ADioswoR7VKkBd/s1hNw/G4ILasLSA0k2Kw1M57r1kA==
+
 dir-glob@^3.0.1:
   version "3.0.1"
   resolved "https://registry.yarnpkg.com/dir-glob/-/dir-glob-3.0.1.tgz#56dbf73d992a4a93ba1584f4534063fd2e41717f"


### PR DESCRIPTION
制作案件では必ず destyle.css を利用しているようなので、boilerplate に含めてしまったほうがいいのではないでしょうか。
制作案件のリポジトリを見られないのでソースは載せられないのですが、 @cc-shikinami @cc-Tanaka にはヒアリングして基本的にすべての案件で destyle.css を利用していることを確認しました。

制作案件のプロジェクトでは、 destyle.css のファイルをペーストして使っているようでしたが、今回は npm でインストールするようにしました。

[Destyle.css - Opinionated reset stylesheet that provides a clean slate for styling your html.](https://nicolas-cusan.github.io/destyle.css/)