### PR TITLE
ESLint の shareable config を利用して、ESLint の設定は shareable config の方で一元管理する

### DIFF
--- a/.eslintrc.js
+++ b/.eslintrc.js
@@ -1,34 +1,5 @@
 module.exports = {
-  env: {
-    es2017: true,
-    browser: true,
-    es2020: false,
-    es2021: false
-  },
-  parserOptions: {
-    ecmaVersion: 2017
-  },
-  extends: [
-    'standard',
-    'plugin:jsdoc/recommended'
-  ],
-  rules: {
-    'no-console': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    'no-debugger': process.env.NODE_ENV === 'production' ? 'error' : 'off',
-    'jsdoc/require-jsdoc': [
-      'error',
-      {
-        require: {
-          ArrowFunctionExpression: true,
-          ClassDeclaration: true,
-          FunctionDeclaration: true,
-          MethodDefinition: true
-        }
-      }
-    ],
-    'jsdoc/require-param-description': 'off',
-    'jsdoc/require-returns-description': 'off'
-  },
+  extends: 'colorfulcompany/browser',
   ignorePatterns: [
     'vendor/**/*.js'
   ]

--- a/package.json
+++ b/package.json
@@ -35,6 +35,7 @@
     "csstools-postcss-sass-pre-release": "^5.0.0-dev.1",
     "esbuild": "^0.13.4",
     "eslint": "^7.32.0",
+    "eslint-config-colorfulcompany": "https://github.com/colorfulcompany/eslint-config-colorfulcompany#v1.0.0",
     "eslint-config-standard": "^16.0.3",
     "eslint-plugin-import": "^2.23.4",
     "eslint-plugin-jsdoc": "^36.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -1218,6 +1218,10 @@ escape-string-regexp@^4.0.0:
   resolved "https://registry.yarnpkg.com/escape-string-regexp/-/escape-string-regexp-4.0.0.tgz#14ba83a5d373e3d311e5afca29cf5bfad965bf34"
   integrity sha512-TtpcNJ3XAzx3Gq8sWRzJaVajRs0uVxA2YAkdb1jm2YkPz4G6egUFAyA3n5vtEIZefPk5Wa4UXbKuS5fKkJWdgA==
 
+"eslint-config-colorfulcompany@https://github.com/colorfulcompany/eslint-config-colorfulcompany#v1.0.0":
+  version "1.0.0"
+  resolved "https://github.com/colorfulcompany/eslint-config-colorfulcompany#9be9e504f5350b4675dd46218c17ee6e25473527"
+
 eslint-config-standard@^16.0.3:
   version "16.0.3"
   resolved "https://registry.yarnpkg.com/eslint-config-standard/-/eslint-config-standard-16.0.3.tgz#6c8761e544e96c531ff92642eeb87842b8488516"


### PR DESCRIPTION
[colorfulcompany/eslint-config-colorfulcompany: Colorful Company's ESLint config](https://github.com/colorfulcompany/eslint-config-colorfulcompany) を導入したので、boilerplate でも利用して、ESLint の設定をできるだけ一箇所で管理・議論できるようにしたいです。

今回は、ブラウザ向けのソースコードが対象なので `colorfulcompany/browser` を利用しています。
一部、`process.env` を利用しているコードがありますが、 `colorfulcompany/browser`  では、バンドラーを利用することを考慮して、Node.js の environment を有効にしているので extends するだけで問題ありません。

## ■ 設定の変化
参考：
- [eslint-config-colorfulcompany/base.js at main · colorfulcompany/eslint-config-colorfulcompany](https://github.com/colorfulcompany/eslint-config-colorfulcompany/blob/main/base.js)
- [eslint-config-colorfulcompany/browser.js at main · colorfulcompany/eslint-config-colorfulcompany](https://github.com/colorfulcompany/eslint-config-colorfulcompany/blob/main/browser.js)

一点、shareable config の導入で `import/no-default-export` が有効になりました。