### PR TITLE
rename stylelint.config.js to .stylelintrc.json

### DIFF
--- a/.stylelintrc.json
+++ b/.stylelintrc.json
@@ -1,0 +1,3 @@
+{
+  "extends": "stylelint-config-standard"
+}

--- a/stylelint.config.cjs
+++ b/stylelint.config.cjs
@@ -1,3 +1,0 @@
-module.exports = {
-  extends: 'stylelint-config-standard'
-}


### PR DESCRIPTION
設定ファイルの拡張子がstylelintの動作モード（esm or cjs）の切り替えに影響しないようにJSONに変更