### PR TITLE
typo with license

### DIFF
--- a/install.cjs
+++ b/install.cjs
@@ -93,7 +93,7 @@ function modifyPackageJson () {
   json.unset('bin')
   json.unset('main')
   json.unset('keywords')
-  json.unset('lisence')
+  json.unset('license')
   json.unset('homepage')
   json.unset('repository')
   json.save()


### PR DESCRIPTION
package.json 内の license の項目を消すことができておらず、boilerplate をテンプレートとして使ったサイトがすべて MIT になってしまう問題を修正